### PR TITLE
Add ESP-IDF 5.4 build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ The repo's structure is designed to be easily implemented.
 We have two possible cmakes to use:
 - src/base.cmake (Includes only tflite micro)
 - src/full.cmake (Includes additional libraries like ulab)
+
+## Building for ESP-IDF 5.4
+
+A helper script `scripts/build_and_check.sh` can be used to build the firmware for a given board using ESP-IDF 5.4.  The script follows the same steps as the GitHub workflow and will fetch the required ESP-IDF release if missing.
+
+```bash
+# Build firmware for the default MICROLITE board
+./scripts/build_and_check.sh
+
+# Or specify a board
+./scripts/build_and_check.sh MICROLITE_S3
+```
+
+The script expects the submodules to be accessible over the network in order to fetch Micropython and related dependencies.

--- a/scripts/build_and_check.sh
+++ b/scripts/build_and_check.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+BOARD=${1:-MICROLITE}
+IDF_VERSION=${IDF_VERSION:-v5.4}
+
+# Update submodules required for build
+if [ ! -d third_party/micropython ]; then
+    echo "Micropython submodule missing" >&2
+    exit 1
+fi
+
+git submodule update --init --recursive
+pushd third_party/micropython >/dev/null
+# ensure required nested submodules
+git submodule update --init lib/axtls
+git submodule update --init lib/berkeley-db-1.xx
+popd >/dev/null
+
+# Fetch esp-idf if not already present
+if [ ! -d esp-idf ]; then
+    git clone --branch "$IDF_VERSION" --depth 1 --recursive https://github.com/espressif/esp-idf.git
+    pushd esp-idf >/dev/null
+    ./install.sh
+    popd >/dev/null
+fi
+
+# Source esp-idf environment
+source ./esp-idf/export.sh
+
+# Build micropython cross compiler
+pushd third_party/micropython >/dev/null
+make -C mpy-cross V=1 clean all
+popd >/dev/null
+
+# Build firmware for the selected board
+pushd boards/${BOARD} >/dev/null
+rm -rf build
+idf.py clean build
+chmod +x ../../scripts/assemble-unified-image-esp.sh
+../../scripts/assemble-unified-image-esp.sh ../../third_party/micropython/ports/esp32
+popd >/dev/null
+
+echo "Build complete for board ${BOARD}" 


### PR DESCRIPTION
## Summary
- provide helper script `build_and_check.sh` to build firmware using ESP-IDF 5.4
- document script usage in README

## Testing
- `shellcheck scripts/build_and_check.sh`
- `bash -x ./scripts/build_and_check.sh MICROLITE` *(fails: HTTP 403 when cloning submodules)*

------
https://chatgpt.com/codex/tasks/task_e_684985b3a38c832fb6b79f28d4340300