### PR TITLE
Fix build by disabling LAN867x PHY

### DIFF
--- a/boards/MICROLITE/mpconfigboard.h
+++ b/boards/MICROLITE/mpconfigboard.h
@@ -1,2 +1,8 @@
 #define MICROPY_HW_BOARD_NAME "ESP32 module (microlite)"
 #define MICROPY_HW_MCU_NAME "ESP32"
+
+// Disable LAN867x Ethernet PHY by default as the required header may not be
+// available with all ESP-IDF versions.
+#ifndef PHY_LAN867X_ENABLED
+#define PHY_LAN867X_ENABLED (0)
+#endif


### PR DESCRIPTION
## Summary
- disable LAN867x PHY driver by default so build doesn't require missing `esp_eth_phy_lan867x.h`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684989b96434832fa7018303d4ba5951