### PR TITLE
Fix workflow order for IDF setup

### DIFF
--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10.16
+
+      - name: Setup IDF
+        run: |
+          source ./third_party/micropython/tools/ci.sh && ci_esp32_idf_setup
+
       - name: Prepare to Build Tensorflow Micropython Firmware for ESP32
         run: |
           git submodule init
@@ -49,15 +58,6 @@ jobs:
           cd ports/esp32
           make BOARD= submodules
           cd ../../../
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.10.16
-
-      - name: Setup IDF
-        run: |
-          source ./third_party/micropython/tools/ci.sh && ci_esp32_idf_setup
 
       - name: Setup Build for Tensorflow
         run: |


### PR DESCRIPTION
## Summary
- set up the IDF environment before running `make submodules`

## Testing
- `./scripts/build_and_check.sh MICROLITE` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68498c430b24832fbdc044e36942746f