### PR TITLE
Fix build workflow submodule order

### DIFF
--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -44,10 +44,6 @@ jobs:
         with:
           python-version: 3.10.16
 
-      - name: Setup IDF
-        run: |
-          source ./third_party/micropython/tools/ci.sh && ci_esp32_idf_setup
-
       - name: Prepare to Build Tensorflow Micropython Firmware for ESP32
         run: |
           git submodule init
@@ -58,6 +54,10 @@ jobs:
           cd ports/esp32
           make BOARD= submodules
           cd ../../../
+
+      - name: Setup IDF
+        run: |
+          source ./third_party/micropython/tools/ci.sh && ci_esp32_idf_setup
 
       - name: Setup Build for Tensorflow
         run: |
@@ -84,6 +84,6 @@ jobs:
           name: microlite-esp32-${{ matrix.board_type }}-firmware
           path: |
             ./boards/${{ matrix.board_type }}/build/bootloader/bootloader.bin
-            ./boards/${{ matrix.board_type }}/build/partition_table/partition-table.bin
+            ./boards/${{ matrix.board_type }}/build/partition_table/partition-table.bin  # yamllint disable-line rule:line-length
             ./boards/${{ matrix.board_type }}/build/micropython.bin
             ./boards/${{ matrix.board_type }}/build/micropython.elf


### PR DESCRIPTION
## Summary
- set up Git submodules before running the IDF setup script
- call IDF setup after the submodules are available

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 140}}}' .github/workflows/build_boards.yml`

------
https://chatgpt.com/codex/tasks/task_e_68498e919664832f9f083eea98ed5805