### PR TITLE
Add lan867x via component manifest

### DIFF
--- a/boards/MICROLITE/CMakeLists.txt
+++ b/boards/MICROLITE/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE/main/CMakeLists.txt
+++ b/boards/MICROLITE/main/CMakeLists.txt
@@ -5,18 +5,7 @@ message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
 
-
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 
 set(PROJECT_DIR ${MICROPY_DIR}/ports/esp32)
-
-# ——————————————————————————————————————————————————————————————
-# Ensure ESP-Ethernet is built alongside the other IDF components
-# ——————————————————————————————————————————————————————————————
-list(APPEND IDF_COMPONENTS "esp_eth")
-message(STATUS "microlite/main/cmake: IDF_COMPONENTS=${IDF_COMPONENTS}")
-
-# Now include the MicroPython ESP32 build
 include(${PROJECT_DIR}/main/CMakeLists.txt)
-
-message(STATUS "microlite/main/cmake: After IDF_COMPONENTS=${IDF_COMPONENTS}")

--- a/boards/MICROLITE/main/idf_component.yml
+++ b/boards/MICROLITE/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_C3/CMakeLists.txt
+++ b/boards/MICROLITE_C3/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_C3/main/CMakeLists.txt
+++ b/boards/MICROLITE_C3/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_C3/main/idf_component.yml
+++ b/boards/MICROLITE_C3/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_C3_USB/CMakeLists.txt
+++ b/boards/MICROLITE_C3_USB/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_C3_USB/main/CMakeLists.txt
+++ b/boards/MICROLITE_C3_USB/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_C3_USB/main/idf_component.yml
+++ b/boards/MICROLITE_C3_USB/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_S2_SPIRAM/CMakeLists.txt
+++ b/boards/MICROLITE_S2_SPIRAM/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_S2_SPIRAM/main/CMakeLists.txt
+++ b/boards/MICROLITE_S2_SPIRAM/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_S2_SPIRAM/main/idf_component.yml
+++ b/boards/MICROLITE_S2_SPIRAM/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_S3/CMakeLists.txt
+++ b/boards/MICROLITE_S3/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_S3/main/CMakeLists.txt
+++ b/boards/MICROLITE_S3/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_S3/main/idf_component.yml
+++ b/boards/MICROLITE_S3/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_S3_SPIRAM/CMakeLists.txt
+++ b/boards/MICROLITE_S3_SPIRAM/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_S3_SPIRAM/main/CMakeLists.txt
+++ b/boards/MICROLITE_S3_SPIRAM/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_S3_SPIRAM/main/idf_component.yml
+++ b/boards/MICROLITE_S3_SPIRAM/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_S3_SPIRAM_OCTAL/CMakeLists.txt
+++ b/boards/MICROLITE_S3_SPIRAM_OCTAL/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_S3_SPIRAM_OCTAL/main/CMakeLists.txt
+++ b/boards/MICROLITE_S3_SPIRAM_OCTAL/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_S3_SPIRAM_OCTAL/main/idf_component.yml
+++ b/boards/MICROLITE_S3_SPIRAM_OCTAL/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_SPIRAM/CMakeLists.txt
+++ b/boards/MICROLITE_SPIRAM/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_SPIRAM/main/CMakeLists.txt
+++ b/boards/MICROLITE_SPIRAM/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_SPIRAM/main/idf_component.yml
+++ b/boards/MICROLITE_SPIRAM/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_SPIRAM_16M/CMakeLists.txt
+++ b/boards/MICROLITE_SPIRAM_16M/CMakeLists.txt
@@ -27,6 +27,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_SPIRAM_16M/main/CMakeLists.txt
+++ b/boards/MICROLITE_SPIRAM_16M/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_SPIRAM_16M/main/idf_component.yml
+++ b/boards/MICROLITE_SPIRAM_16M/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"

--- a/boards/MICROLITE_SPIRAM_CAM/CMakeLists.txt
+++ b/boards/MICROLITE_SPIRAM_CAM/CMakeLists.txt
@@ -30,6 +30,8 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+set(ENV{IDF_COMPONENT_MANAGER} "1")
+
 # Include main IDF cmake file and define the project.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(micropython)

--- a/boards/MICROLITE_SPIRAM_CAM/main/CMakeLists.txt
+++ b/boards/MICROLITE_SPIRAM_CAM/main/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Include MicroPython ESP32 component.
 
 get_filename_component(CURRENT_DIR "." ABSOLUTE)
-
 message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
 
 get_filename_component(MICROPY_DIR "../../../third_party/micropython" ABSOLUTE)
-
 
 message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
 

--- a/boards/MICROLITE_SPIRAM_CAM/main/idf_component.yml
+++ b/boards/MICROLITE_SPIRAM_CAM/main/idf_component.yml
@@ -1,0 +1,14 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/mdns: "~1.1.0"
+  espressif/esp_tinyusb:
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+    version: "~1.0.0"
+  espressif/lan867x:
+    version: "~1.0.0"
+    rules:
+      - if: "target == esp32"
+      - if: "idf_version >=5.3"
+  idf:
+    version: ">=5.2.0"


### PR DESCRIPTION
## Summary
- enable IDF Component Manager for every board
- provide a manifest adding lan867x and other dependencies
- revert manual esp_eth additions in board `CMakeLists.txt`

## Testing
- `./scripts/build_and_check.sh MICROLITE` *(fails: HTTP 403 while cloning submodules)*


------
https://chatgpt.com/codex/tasks/task_e_6849d2543618832f9ada830876d96c29