### PR TITLE
Remove microfrontend references

### DIFF
--- a/src/base.cmake
+++ b/src/base.cmake
@@ -76,13 +76,6 @@ file(GLOB TF_LITE_API_SRCS
           "${TF_LITE_DIR}/core/api/*.c")
 endif()
 
-# lite experimental
-
-file(GLOB TF_LITE_MICROFRONTEND_SRCS
-          "${TF_LITE_DIR}/experimental/microfrontend/lib/*.c"
-          "${TF_LITE_DIR}/experimental/microfrontend/lib/*.cc"
-          "${TF_LITE_DIR}/experimental/microfrontend/lib/*.cpp")
-
 # lite kernels
 
 file(GLOB TF_LITE_KERNELS_SRCS
@@ -189,7 +182,6 @@ target_sources(microlite INTERFACE
     # tf lite sources
     ${TF_LITE_C_SRCS}
     ${TF_LITE_API_SRCS}
-    ${TF_LITE_MICROFRONTEND_SRCS}
     ${TF_LITE_KERNELS_SRCS}
     ${TF_LITE_SCHEMA_SRCS}
 

--- a/src/microlite/tensorflow-microlite.h
+++ b/src/microlite/tensorflow-microlite.h
@@ -39,8 +39,6 @@ extern "C" {
 #include "py/objstr.h"
 #include "py/objarray.h"
 
-#include "tensorflow/lite/experimental/microfrontend/lib/frontend.h"
-#include "tensorflow/lite/experimental/microfrontend/lib/frontend_util.h"
 
 // TODO #15 get this from the tensorflow submodule via a ci script
 #define TFLITE_MICRO_VERSION "TODO: Give this a real version later. This use to be the version of mocleiris repo"


### PR DESCRIPTION
## Summary
- remove obsolete microfrontend includes from `tensorflow-microlite.h`
- drop microfrontend source files from `base.cmake`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ac4850c98832fb922d5a11185ed00