### PR TITLE
Add helper script for submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ When building with ESP-IDF 5.4 the following submodule commits have been verifie
 
 These versions are pinned via Git submodules. After cloning the repository run
 `git submodule update --init --recursive` to fetch the correct revisions.
+If Git submodules cannot be fetched directly (for example in environments without full Git access), run `scripts/fetch_submodules.sh` which downloads the same revisions using plain HTTP archives.

--- a/scripts/fetch_submodules.sh
+++ b/scripts/fetch_submodules.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Helper to download and extract an archive from codeload.github.com
+# Arguments: repo user/repo, destination directory, commit hash
+fetch() {
+  local repo=$1
+  local dest=$2
+  local commit=$3
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  curl -L "https://codeload.github.com/${repo}/tar.gz/${commit}" -o tmp.tar.gz
+  tar -xzf tmp.tar.gz
+  mv "${repo##*/}-${commit}"/* "$dest"/
+  rm -rf "${repo##*/}-${commit}" tmp.tar.gz
+}
+
+MICROPYTHON_COMMIT=9bde12597a6980ff87ff0137a2616e6e430a1a0e
+ESP_TFLITE_MICRO_COMMIT=772214721682ef2d3eed09cafea777edad55541f
+ESP_NN_COMMIT=12129cf04b09af0023127ca7551dc1a363344211
+MICROPYTHON_ULAB_COMMIT=a05ec05351260cf48fefc347265b8d8bf29c03f1
+
+fetch espressif/esp-nn third_party/esp-nn "$ESP_NN_COMMIT"
+fetch espressif/esp-tflite-micro third_party/esp-tflite-micro "$ESP_TFLITE_MICRO_COMMIT"
+fetch micropython/micropython third_party/micropython "$MICROPYTHON_COMMIT"
+fetch v923z/micropython-ulab third_party/micropython-ulab "$MICROPYTHON_ULAB_COMMIT"
+
+echo "Submodules downloaded"


### PR DESCRIPTION
## Summary
- add `scripts/fetch_submodules.sh` to download third-party sources via HTTP
- document running the script as an alternative to `git submodule update`

## Testing
- `./scripts/fetch_submodules.sh`

------
https://chatgpt.com/codex/tasks/task_e_684acc3143ac832fa8dcd1e7a520de58