### PR TITLE
Fix error_reporter path for ESP-IDF

### DIFF
--- a/src/base.cmake
+++ b/src/base.cmake
@@ -137,9 +137,15 @@ file(GLOB TF_MICRO_TFLITE_BRIDGE_SRCS
           "${TF_MICRO_DIR}/tflite_bridge/*.cc"
           "${TF_MICRO_DIR}/tflite_bridge/*.c")
 
+if (CONFIG_IDF_TARGET)
+file(GLOB TF_MLIR_API_SRCS
+        "${COMPILER_MLIR_DIR}/lite/core/api/error_reporter.cc"
+)
+else()
 file(GLOB TF_MLIR_API_SRCS
         "${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/compiler/mlir/lite/core/api/error_reporter.cc"
 )
+endif()
 
 set (BOARD_ADDITIONAL_SRCS "")
 


### PR DESCRIPTION
## Summary
- fix the CMake path for `error_reporter.cc` when building with ESP-IDF

## Testing
- `./scripts/build_and_check.sh` *(fails: submodules already exist and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684aed0b3144832f99890363be992ad1